### PR TITLE
Remove naming requirements for "Utils" classes.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -55,7 +55,6 @@ checks:
         newline_at_end_of_file: true
         naming_conventions:
             local_variable: '^[a-z][a-zA-Z0-9]*$'
-            utility_class_name: 'Utils?$'
             constant_name: '^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$'
             property_name: '^[a-z][a-zA-Z0-9]*$'
             method_name: '^((?:[a-z]|__)[a-zA-Z0-9]*|test[A-Z][_a-zA-Z0-9]*)$'


### PR DESCRIPTION
Having "Utils" classes is ending up being a code smell in and of itself, so I'm removing the requirement that classes with only static methods be named "Utils(Something)".